### PR TITLE
画面外にボールが出てしまったときにリスタートするように改善、ブロックの作成

### DIFF
--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -263,7 +263,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 128508747}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -8.480659, y: 1.976, z: -0.14303006}
+  m_LocalPosition: {x: -8.6, y: -0.5, z: 0}
   m_LocalScale: {x: 0.56, y: 10.979539, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -511,13 +511,138 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 594086015}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.046941422, y: 7.2980776, z: -0.14303006}
-  m_LocalScale: {x: 17.476368, y: 0.3451296, z: 1}
+  m_LocalPosition: {x: 0.1022, y: 4.8220778, z: 0}
+  m_LocalScale: {x: 17.915462, y: 0.3451296, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1684862013}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &651351992
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 651351995}
+  - component: {fileID: 651351994}
+  - component: {fileID: 651351993}
+  - component: {fileID: 651351996}
+  m_Layer: 0
+  m_Name: 1BreakBlock
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!61 &651351993
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 651351992}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!212 &651351994
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 651351992}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &651351995
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 651351992}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 2.04, z: 0}
+  m_LocalScale: {x: 1.5, y: 0.6, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &651351996
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 651351992}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3af522b1b0a27204d90e36725de3db7c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hitPoint: 1
 --- !u!1 &789498643
 GameObject:
   m_ObjectHideFlags: 0
@@ -844,7 +969,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 925782749}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 8.772641, y: 1.9381, z: -0.14303006}
+  m_LocalPosition: {x: 8.7733, y: -0.53789985, z: 0}
   m_LocalScale: {x: 0.56, y: 11.0553, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -919,7 +1044,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1525732700}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -4.637507, y: 1.0729321, z: 0.18040185}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -1035,7 +1160,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1684862012}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.11804142, y: -2.4659777, z: 0.14303006}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -1060,7 +1185,7 @@ GameObject:
   - component: {fileID: 1819299533}
   m_Layer: 0
   m_Name: Ball
-  m_TagString: Untagged
+  m_TagString: Ball
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Scripts/BallManager.cs
+++ b/Assets/Scripts/BallManager.cs
@@ -34,7 +34,7 @@ public class BallManager : MonoBehaviour
 
     void Update()
     {
-        switch(currentState)
+        switch (currentState)
         {
             case State.INIT:
                 Debug.Log("ボール生成");
@@ -48,11 +48,12 @@ public class BallManager : MonoBehaviour
                 SetState(State.MOVING);
                 break;
             case State.MOVING:
-
+                /*移動処理*/
                 Vector2 currentVelocity = rigidbody.velocity;
                 Debug.Log(currentVelocity);
                 rigidbody.velocity = currentVelocity.normalized * moveSpeed;
 
+                DeadPosition();
                 break;
             case State.DEATH:
                 rigidbody.velocity = new Vector2(0, 0);
@@ -62,10 +63,10 @@ public class BallManager : MonoBehaviour
                 //SetState(State.GAMEOVER);
                 break;
             case State.GAMEOVER:
-                
+
                 break;
             default:
-                
+
                 break;
         }
     }
@@ -75,10 +76,23 @@ public class BallManager : MonoBehaviour
         currentState = setState;
     }
 
+    private void DeadPosition()
+    {
+        if (gameObject.transform.position.x < spawnPos.x - 20 || gameObject.transform.position.x > spawnPos.x + 20)
+        {
+            SetState(State.DEATH);
+        }
+        if(gameObject.transform.position.y < spawnPos.y - 40)
+        {
+            SetState(State.DEATH);
+        }
+    }
+
     private void OnTriggerEnter2D(Collider2D collision)
     {
-        Debug.Log("画面外です");
-        if (collision.gameObject.CompareTag("DeathArea")){
+        if (collision.gameObject.CompareTag("DeathArea"))
+        {
+            Debug.Log("画面外です");
             SetState(State.DEATH);
         }
     }

--- a/Assets/Scripts/BlockController.cs
+++ b/Assets/Scripts/BlockController.cs
@@ -1,0 +1,39 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class BlockController : MonoBehaviour
+{
+    [SerializeField, Header("‰ó‚ê‚é‚Ü‚Å‚Ì‰ñ”")]
+    private int hitPoint = 1;
+
+    private SpriteRenderer spriteRenderer;  //F‚ğ•Ï‚¦‚½‚è‚·‚é‚©‚à
+
+    void Start()
+    {
+        spriteRenderer = gameObject.GetComponent<SpriteRenderer>();
+    }
+
+    void Update()
+    {
+
+    }
+
+    private void OnCollisionEnter2D(Collision2D collision)
+    {
+        if (collision.gameObject.CompareTag("Ball"))
+        {
+            hitPoint--;
+            BreakCheak();
+        }
+    }
+
+    private void BreakCheak()
+    {
+        if (hitPoint <= 0)
+        {
+            gameObject.SetActive(false);
+            Debug.Log("‰ó‚ê‚éII");
+        }
+    }
+}

--- a/Assets/Scripts/BlockController.cs.meta
+++ b/Assets/Scripts/BlockController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3af522b1b0a27204d90e36725de3db7c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BlockManager.cs
+++ b/Assets/Scripts/BlockManager.cs
@@ -1,0 +1,18 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class BlockManager : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/Assets/Scripts/BlockManager.cs.meta
+++ b/Assets/Scripts/BlockManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5f3b6f17eb799dd4bb7222a9ae6c16a2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -6,6 +6,7 @@ TagManager:
   tags:
   - Wall
   - DeathArea
+  - Ball
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
やったこと
・画面外にボールが出てしまったときにリスタートするように改善
・ブロックの作成

現状できていること
・ボールの生成される位置から右に20、左に20、下に20の場所にボールがあるときステートをDeathにするようにした。
・仮でブロックを作成し、ボールが一発当たったら非表示にするようにできた。

まだできていないこと
・ブロックのプレハブ化
・ブロックの生成される位置からではなく画面の真ん中からにしたほうがよさそう

解決した点
・画面外にボールが出たら、Deathステートに移動するためデットロックは回避

スクショ
前回とあまり変わらないので割愛