### PR TITLE
ボールの回転速度の異常値を取り除く処理を追加

### DIFF
--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -2572,6 +2572,10 @@ PrefabInstance:
       value: Ball
       objectReference: {fileID: 0}
     - target: {fileID: 3221330443540692933, guid: 87ad50e1e911f3e44925a99cd1dd0d27, type: 3}
+      propertyPath: boundSound
+      value: 
+      objectReference: {fileID: 8300000, guid: 3b226b54eac7c4f4393f9ea4a0e87718, type: 3}
+    - target: {fileID: 3221330443540692933, guid: 87ad50e1e911f3e44925a99cd1dd0d27, type: 3}
       propertyPath: startMove.x
       value: 0
       objectReference: {fileID: 0}
@@ -2741,7 +2745,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1473957432
 RectTransform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Ball/BallRotation.cs
+++ b/Assets/Scripts/Ball/BallRotation.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 public class BallRotation : MonoBehaviour
 {
     private float previousRotation; //1フレーム前の角度
+    private float previousRotationSpeed; //1フレーム前の回転速度
     [SerializeField]
     private float rotationSpeed;    //回転速度
     [SerializeField]
@@ -11,6 +12,7 @@ public class BallRotation : MonoBehaviour
     void Start()
     {
         previousRotation = transform.rotation.eulerAngles.z;
+        previousRotationSpeed = 0;
     }
 
     void Update()
@@ -21,14 +23,15 @@ public class BallRotation : MonoBehaviour
         //回転速度の計算
         rotationSpeed = deltaRotation * Mathf.Deg2Rad / Time.deltaTime;
 
-        if(rotationSpeed > 300)
+        //前のフレームの回転速度と比較してその回転速度の1.5倍以上差があったら
+        //異常値を前の速度に変える
+        //まだ取り逃している時がある
+        if(Mathf.Abs(rotationSpeed) > Mathf.Abs(previousRotationSpeed * 1.5f))
         {
-            rotationSpeed = -50;
+            //Debug.Log($"異常値です:{rotationSpeed} > {previousRotationSpeed} * 1.5");
+            rotationSpeed = previousRotationSpeed;
         }
-        else if(rotationSpeed < -300)
-        {
-            rotationSpeed = 50;
-        }
+
         rotationSpeed = CalculateRoundHalfUp(rotationSpeed, 2);
         //Debug.Log(rotationSpeed);
 
@@ -47,6 +50,8 @@ public class BallRotation : MonoBehaviour
         }
 
         previousRotation = transform.rotation.eulerAngles.z;
+        //previousRotationSpeed = rotationSpeed;
+        previousRotationSpeed = deltaRotation * Mathf.Deg2Rad / Time.deltaTime;
     }
 
     public float GetRotationSpeed


### PR DESCRIPTION
やったこと
・ボールの回転速度の異常値を取り除く処理を追加

書いておきたいこと
・ボールの回転速度をスクリプトから取得しようとすると数フレームに一回異常値が出る。
→ボールの回転速度の異常値を取り除くために1フレーム前の回転速度と現在の回転速度を比べて、
　1フレーム前の回転速度より1.5倍の速度を取得してしまっていたら、
　現在の回転速度を1フレーム前の回転速度と同じにするという処理を書いた。

やってないこと
音・デザイン
ステージ作成