### PR TITLE
設定の保存先を変更、ビルド上での音源が再生されない問題を解決

### DIFF
--- a/Assets/Scripts/Setting/AudioVolume.cs
+++ b/Assets/Scripts/Setting/AudioVolume.cs
@@ -20,9 +20,16 @@ public class AudioVolume : MonoBehaviour
     {
         bgmSlider.maxValue = maxValue;
         //seSlider.maxValue = maxValue;
-
-        bgmSlider.value = BGMValue;
-        seSlider.value = SEValue;
+        if (BGMValue == 0 && SEValue == 0)
+        {
+            bgmSlider.value = 65;
+            seSlider.value = 70;
+        }
+        else
+        {
+            bgmSlider.value = BGMValue;
+            seSlider.value = SEValue;
+        }
 
         bgmSlider.onValueChanged.AddListener(SetAudioMixerBGM);
         seSlider.onValueChanged.AddListener(SetAudioMixerSE);

--- a/Assets/Scripts/Setting/SettingManager.cs
+++ b/Assets/Scripts/Setting/SettingManager.cs
@@ -20,8 +20,27 @@ public class SettingManager : MonoBehaviour
     [SerializeField, Header("クラス参照系")]
     private AudioVolume audioVolume;
 
+    private string filePath; // ファイルのパスを指定
+
     private void Awake()
     {
+        filePath = Application.persistentDataPath + "/settingdata.json";
+        if (File.Exists(filePath))
+        {
+            Debug.Log("JSONファイルが存在します。");
+        }
+        else
+        {
+            Debug.Log("JSONファイルが存在しません。");
+            Setting firstSetting = new Setting();
+            firstSetting.BGMValue = 60;
+            firstSetting.SEValue = 75;
+
+            string jsonstr = JsonUtility.ToJson(firstSetting);
+            File.WriteAllText(filePath, jsonstr);
+            Debug.Log("ファイルの生成に成功しました");
+        }
+
         Setting setting = LoadSettingData();
 
         audioVolume.AudioInit(setting.BGMValue, setting.SEValue);
@@ -45,7 +64,7 @@ public class SettingManager : MonoBehaviour
 
         string jsonstr = JsonUtility.ToJson(setting);
 
-        writer = new StreamWriter(Application.dataPath + "/datas/settingdata.json", false);
+        writer = new StreamWriter(filePath, false);
         writer.Write(jsonstr);
         writer.Flush();
         writer.Close();
@@ -56,7 +75,7 @@ public class SettingManager : MonoBehaviour
     {
         string datastr = "";
         StreamReader reader;
-        reader = new StreamReader(Application.dataPath + "/datas/settingdata.json");
+        reader = new StreamReader(filePath);
         datastr = reader.ReadToEnd();
         reader.Close();
 

--- a/Assets/datas.meta
+++ b/Assets/datas.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 46985fd7e7e16b446a355b004d158bf8
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/datas/settingdata.json
+++ b/Assets/datas/settingdata.json
@@ -1,1 +1,0 @@
-{"BGMValue":65.0,"SEValue":70.0}

--- a/Assets/datas/settingdata.json.meta
+++ b/Assets/datas/settingdata.json.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: e81f3c2c3cb4f724982e2df761fee41d
-TextScriptImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -12,7 +12,7 @@ PlayerSettings:
   targetDevice: 2
   useOnDemandResources: 0
   accelerometerFrequency: 60
-  companyName: Nishizawa_Tomoya
+  companyName: Nishizawa_TomoyaTest
   productName: BlockBreakerByTabletennis
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
@@ -134,7 +134,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 1.1.3
+  bundleVersion: 1.2.0
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0
@@ -270,7 +270,14 @@ PlayerSettings:
   AndroidMinifyDebug: 0
   AndroidValidateAppBundleSize: 1
   AndroidAppBundleSizeToValidate: 150
-  m_BuildTargetIcons: []
+  m_BuildTargetIcons:
+  - m_BuildTarget: 
+    m_Icons:
+    - serializedVersion: 2
+      m_Icon: {fileID: 2800000, guid: 5c1d13007fb90a746bffeec18d9c4d96, type: 3}
+      m_Width: 128
+      m_Height: 128
+      m_Kind: 0
   m_BuildTargetPlatformIcons:
   - m_BuildTarget: Android
     m_Icons:
@@ -722,7 +729,7 @@ PlayerSettings:
   allowUnsafeCode: 0
   useDeterministicCompilation: 1
   enableRoslynAnalyzers: 1
-  selectedPlatform: 3
+  selectedPlatform: 0
   additionalIl2CppArgs: 
   scriptingRuntimeVersion: 1
   gcIncremental: 1


### PR DESCRIPTION
やったこと
設定の保存をしていた場所がAssetsフォルダの中だったがビルド上では参照できないとわかったため、
Cドライブ上にJSONファイルを生成し、そこで読み書きをするようにした。
上記の方法を行って、ビルド上でも音源の再生に問題が起きなくなった。


 - close https://github.com/tontan1122/BlockBreaker_TableTennis/issues/50