### PR TITLE
画面クリックの範囲をスクリーンサイズを取得して決めるようにしました。

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -51,8 +51,7 @@ public class GameManager : MonoBehaviour
     [SerializeField, Header("現在のレベル")]
     private int currentLevel = 0;
 
-    [SerializeField, Header("クリックを感知する画面高さ")]
-    const int heightUnavailableClick = 450;
+    private int heightUnavailableClick = Screen.height / 5 * 4;
 
     private bool isHintPanelActive = false; // ヒントパネルを一度表示したかどうか
     private bool isStopGame = false;    // ボールがプレイヤーの情報を使うかどうか


### PR DESCRIPTION
設定ボタンをクリックしたときにボールを放たないようにするための範囲を決める（放てる箇所を決める）とき、
今までは座標で決めていたが、スクリーンサイズが変わったときに対応できないため、
スクリーンサイズを取得して、そこからの割合で決めることにした。