### PR TITLE
設定画面で弾を放てないようにした

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -359,6 +359,7 @@ public class GameManager : MonoBehaviour
         uiManager.SettingActive(true);
         cursorController.CursorOn();
         isStopGame = true;  // ƒQ[ƒ€‚ğˆê’â~‚·‚é
+        ballManager.SetIsShot = false;  // ƒ{[ƒ‹‚ğ•ú‚Ä‚È‚¢‚æ‚¤‚É‚·‚é
     }
 
     /// <summary>

--- a/Assets/Scripts/Setting/SettingManager.cs
+++ b/Assets/Scripts/Setting/SettingManager.cs
@@ -20,6 +20,12 @@ public class SettingManager : MonoBehaviour
     [SerializeField, Header("クラス参照系")]
     private AudioVolume audioVolume;
 
+    [SerializeField, Header("BGMの初期設定")]
+    private int firstBGMValue = 60;
+
+    [SerializeField, Header("SEの初期設定")]
+    private int firstSEValue = 75;
+
     private string filePath; // ファイルのパスを指定
 
     private void Awake()
@@ -33,8 +39,8 @@ public class SettingManager : MonoBehaviour
         {
             Debug.Log("JSONファイルが存在しません。");
             Setting firstSetting = new Setting();
-            firstSetting.BGMValue = 60;
-            firstSetting.SEValue = 75;
+            firstSetting.BGMValue = firstBGMValue;
+            firstSetting.SEValue = firstSEValue;
 
             string jsonstr = JsonUtility.ToJson(firstSetting);
             File.WriteAllText(filePath, jsonstr);

--- a/Assets/Scripts/Stage/StageManager.cs
+++ b/Assets/Scripts/Stage/StageManager.cs
@@ -46,8 +46,8 @@ public class StageManager : MonoBehaviour
         /*switch文に当てはまるものは特殊なステージを生成する場合である*/
         switch (currentLevel)   // どのステージが特殊かどうか
         {
-            case 11:
-            case 12:
+            case 16:
+            case 17:
                 stages.Add(stageGenerator.NoCeilingGeneration(continuousClear));
                 isSpecialStage = true;
                 break;


### PR DESCRIPTION
やったこと
・設定画面で弾を放てないようにした
　→gameManagerから設定を開いたときにボールのisShotフラグをfarceにすることで解決
・初回起動時の音量をinspectorから変えれるようになった
・天井なしステージの生成ステージ番号がずれていたことによる生成ミスを修正

- close https://github.com/tontan1122/BlockBreaker_TableTennis/issues/56