### PR TITLE
タイトル遷移時ヒントの再生を止めるようにした

### DIFF
--- a/Assets/Scripts/Hint/HintPlay.cs
+++ b/Assets/Scripts/Hint/HintPlay.cs
@@ -20,6 +20,8 @@ internal class HintPlay : MonoBehaviour
 
     private int stageCount = 0; //連続ステージクリア数
 
+    private bool isHintPlay = false;
+
     void Start()
     {
         ballTransform = hintBall.transform;
@@ -35,6 +37,12 @@ internal class HintPlay : MonoBehaviour
             pos.x = ballPositionList[i].x;
             pos.y = ballPositionList[i].y + stageCount * GlobalConst.STAGE_SIZE_Y;
             ballTransform.position = pos;
+
+            if (!isHintPlay)
+            {
+                break;
+            }
+
             yield return null;  //１フレーム停止
         }
         Debug.Log("ヒント終了");
@@ -44,8 +52,14 @@ internal class HintPlay : MonoBehaviour
     internal void HintStart(int sc, int level)
     {
         hintBall.SetActive(true);
+        isHintPlay = true;
         stageCount = sc - 1;    //-1は一ステージ目ですべて録画しているため
         ballPositionList = hintLoad.LoadHintData(level);
         StartCoroutine(nameof(HintMove));
+    }
+
+    internal void HintStop()
+    {
+        isHintPlay = false;
     }
 }

--- a/Assets/Scripts/Stage/StageManager.cs
+++ b/Assets/Scripts/Stage/StageManager.cs
@@ -137,6 +137,8 @@ internal class StageManager : MonoBehaviour
 
         blockManager.BlockDestroy(); // ブロックの削除
 
+        hintPlay.HintStop();    // ヒントの再生を止める
+
         continuousClear = 0;    //連続クリア数のリセット
         blockManager.IsClear = false;
     }


### PR DESCRIPTION
やったこと
・タイトル遷移時にヒントが止まるようになった。
　→別のステージのヒントが続けて再生されているということはなくなったと思われる。
- close https://github.com/tontan1122/BlockBreaker_TableTennis/issues/78