### PR TITLE
ヒントが途中から再生される問題を解決

### DIFF
--- a/Assets/Scripts/Hint/HintPlay.cs
+++ b/Assets/Scripts/Hint/HintPlay.cs
@@ -46,13 +46,17 @@ internal class HintPlay : MonoBehaviour
             yield return null;  //１フレーム停止
         }
         Debug.Log("ヒント終了");
+        HintStop();
         hintBall.SetActive(false);
     }
 
     internal void HintStart(int sc, int level)
-    {
+    { 
         hintBall.SetActive(true);
-        isHintPlay = true;
+        if (!isHintPlay)
+        {
+            isHintPlay = true;
+        }
         stageCount = sc - 1;    //-1は一ステージ目ですべて録画しているため
         ballPositionList = hintLoad.LoadHintData(level);
         StartCoroutine(nameof(HintMove));


### PR DESCRIPTION
やったこと
・ヒントが途中から再生される問題を解決
　→ヒントを再生中かどうかという変数を持たせ、再生中じゃないときにはヒントを止めるようにするようにして解決

- close https://github.com/tontan1122/BlockBreaker_TableTennis/issues/81