### PR TITLE
縦移動バーの移動範囲修正

### DIFF
--- a/Assets/Scripts/Gimmick/VerticalMovePlayer.cs
+++ b/Assets/Scripts/Gimmick/VerticalMovePlayer.cs
@@ -4,6 +4,15 @@ internal class VerticalMovePlayer : PlayerController
 {
     [SerializeField, Header("移動範囲：Y")]
     private float moveLimitY;
+
+    private float firstPosY = 0;
+
+    private void Start()
+    {
+        firstPosY = this.gameObject.transform.position.y;
+        playerRigidbody = this.gameObject.GetComponent<Rigidbody2D>();
+    }
+
     protected override void PlayerMove()
     {
         Vector2 mousePosition = Input.mousePosition;
@@ -21,7 +30,9 @@ internal class VerticalMovePlayer : PlayerController
         Vector3 currentPos = transform.position;
 
         //Mathf.ClampでXの値を最小～最大の範囲内に収める。
-        currentPos.y = Mathf.Clamp(currentPos.y, -moveLimitY, moveLimitY);
+        currentPos.y = Mathf.Clamp(currentPos.y, -moveLimitY + firstPosY, moveLimitY + firstPosY);
+
+        Debug.Log(currentPos);
 
         //端だったときに動く処理を行わないようにする処理
         if (currentPos.y == moveLimitY)

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -19,12 +19,12 @@ internal class PlayerController : MonoBehaviour
 
     private bool isControl = true;      //“®‚©‚¹‚é‚©‚Ç‚¤‚©
 
-    void Start()
+    private void Start()
     {
         playerRigidbody = this.gameObject.GetComponent<Rigidbody2D>();
     }
 
-    void Update()
+    private void Update()
     {
         PlayerMove();   // ˆÚ“®ˆ—
 


### PR DESCRIPTION
やったこと
・縦移動バーが一ステージ目に取り残されてしまう問題を解決
　→y座標はステージ移動によってどんどん変動されているため、一ステージ目しか移動できないようになっていた
　　バーの初期位置を利用して問題を解決

- close https://github.com/tontan1122/BlockBreaker_TableTennis/issues/86