### PR TITLE
ポーズをTimeScaleではない方法で実装、ポーズにUIアニメーションを実装

### DIFF
--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -12761,6 +12761,51 @@ Transform:
   m_Father: {fileID: 1525732701}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1331611784
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1331611785}
+  - component: {fileID: 1331611786}
+  m_Layer: 0
+  m_Name: RigidbodyStopper
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1331611785
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1331611784}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1525732701}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1331611786
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1331611784}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2ae4f56fee314bf4ca083bf7825f09a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  pauseRigidbodys: []
 --- !u!1 &1340096558
 GameObject:
   m_ObjectHideFlags: 0
@@ -14986,6 +15031,7 @@ Transform:
   - {fileID: 1200103347}
   - {fileID: 1331179785}
   - {fileID: 2054233137}
+  - {fileID: 1331611785}
   m_Father: {fileID: 0}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -4114,8 +4114,8 @@ MonoBehaviour:
         m_CallState: 2
       - m_Target: {fileID: 1964491439}
         m_TargetAssemblyTypeName: GameAudioManager, Assembly-CSharp
-        m_MethodName: ClickButtonAudio
-        m_Mode: 1
+        m_MethodName: PlayGameSE
+        m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -6048,8 +6048,8 @@ MonoBehaviour:
         m_CallState: 2
       - m_Target: {fileID: 1964491439}
         m_TargetAssemblyTypeName: GameAudioManager, Assembly-CSharp
-        m_MethodName: ClickButtonAudio
-        m_Mode: 1
+        m_MethodName: PlayGameSE
+        m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -8522,10 +8522,10 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 367252594}
-        m_TargetAssemblyTypeName: PauseUIController, Assembly-CSharp
-        m_MethodName: Resume
-        m_Mode: 1
+      - m_Target: {fileID: 2067438181}
+        m_TargetAssemblyTypeName: UIManager, Assembly-CSharp
+        m_MethodName: PausePanelActive
+        m_Mode: 6
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -8536,8 +8536,8 @@ MonoBehaviour:
         m_CallState: 2
       - m_Target: {fileID: 1964491439}
         m_TargetAssemblyTypeName: GameAudioManager, Assembly-CSharp
-        m_MethodName: ClickButtonAudio
-        m_Mode: 1
+        m_MethodName: PlayGameSE
+        m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -9570,8 +9570,8 @@ MonoBehaviour:
         m_CallState: 2
       - m_Target: {fileID: 1964491439}
         m_TargetAssemblyTypeName: GameAudioManager, Assembly-CSharp
-        m_MethodName: ClickButtonAudio
-        m_Mode: 1
+        m_MethodName: PlayGameSE
+        m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -9849,10 +9849,22 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+      - m_Target: {fileID: 2067438181}
+        m_TargetAssemblyTypeName: UIManager, Assembly-CSharp
+        m_MethodName: PausePanelActive
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
       - m_Target: {fileID: 1964491439}
         m_TargetAssemblyTypeName: GameAudioManager, Assembly-CSharp
-        m_MethodName: ClickButtonAudio
-        m_Mode: 1
+        m_MethodName: PlayGameSE
+        m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -11914,6 +11926,8 @@ GameObject:
   - component: {fileID: 1217413408}
   - component: {fileID: 1217413410}
   - component: {fileID: 1217413409}
+  - component: {fileID: 1217413411}
+  - component: {fileID: 1217413412}
   m_Layer: 5
   m_Name: PausePanel
   m_TagString: Untagged
@@ -11984,6 +11998,40 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1217413407}
   m_CullTransparentMesh: 1
+--- !u!114 &1217413411
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1217413407}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3c531421d7d238340af21e42512a4918, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  layer: 0
+--- !u!95 &1217413412
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1217413407}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 72fd61520ac59e14b8125afb090a6837, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!1 &1223725647
 GameObject:
   m_ObjectHideFlags: 0
@@ -13023,17 +13071,29 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1964491439}
-        m_TargetAssemblyTypeName: GameAudioManager, Assembly-CSharp
-        m_MethodName: ClickButtonAudio
-        m_Mode: 1
+      - m_Target: {fileID: 2067438181}
+        m_TargetAssemblyTypeName: UIManager, Assembly-CSharp
+        m_MethodName: PausePanelActive
+        m_Mode: 6
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
           m_StringArgument: 
-          m_BoolArgument: 0
+          m_BoolArgument: 1
+        m_CallState: 2
+      - m_Target: {fileID: 1964491439}
+        m_TargetAssemblyTypeName: GameAudioManager, Assembly-CSharp
+        m_MethodName: PlayGameSE
+        m_Mode: 3
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
         m_CallState: 2
 --- !u!114 &1356369408
 MonoBehaviour:
@@ -13437,30 +13497,6 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 296534039}
-        m_TargetAssemblyTypeName: StageManager, Assembly-CSharp
-        m_MethodName: HintClick
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 367252594}
-        m_TargetAssemblyTypeName: PauseUIController, Assembly-CSharp
-        m_MethodName: Resume
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
       - m_Target: {fileID: 1881659735}
         m_TargetAssemblyTypeName: GameManager, Assembly-CSharp
         m_MethodName: BackGame
@@ -13473,9 +13509,33 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+      - m_Target: {fileID: 2067438181}
+        m_TargetAssemblyTypeName: UIManager, Assembly-CSharp
+        m_MethodName: PausePanelActive
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
       - m_Target: {fileID: 1964491439}
         m_TargetAssemblyTypeName: GameAudioManager, Assembly-CSharp
-        m_MethodName: ClickButtonAudio
+        m_MethodName: PlayGameSE
+        m_Mode: 3
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 296534039}
+        m_TargetAssemblyTypeName: StageManager, Assembly-CSharp
+        m_MethodName: HintClick
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -16474,8 +16534,20 @@ MonoBehaviour:
         m_CallState: 2
       - m_Target: {fileID: 1964491439}
         m_TargetAssemblyTypeName: GameAudioManager, Assembly-CSharp
-        m_MethodName: ClickButtonAudio
-        m_Mode: 1
+        m_MethodName: PlayGameSE
+        m_Mode: 3
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 2067438181}
+        m_TargetAssemblyTypeName: UIManager, Assembly-CSharp
+        m_MethodName: PausePanelActive
+        m_Mode: 6
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -18487,8 +18559,8 @@ MonoBehaviour:
         m_CallState: 2
       - m_Target: {fileID: 1964491439}
         m_TargetAssemblyTypeName: GameAudioManager, Assembly-CSharp
-        m_MethodName: ClickButtonAudio
-        m_Mode: 1
+        m_MethodName: PlayGameSE
+        m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -20419,11 +20491,13 @@ MonoBehaviour:
   selectStageController: {fileID: 335242820}
   gameUIController: {fileID: 717661359}
   resultController: {fileID: 1473957435}
+  pauseUIController: {fileID: 367252594}
   panelActiveAnimation:
   - {fileID: 335242821}
   - {fileID: 1473957436}
   - {fileID: 2015548296}
   - {fileID: 1162643353}
+  - {fileID: 1217413411}
 --- !u!1 &2069864499
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Audio/GameAudioManager.cs
+++ b/Assets/Scripts/Audio/GameAudioManager.cs
@@ -20,7 +20,7 @@ internal class GameAudioManager : MonoBehaviour
     /// 1：ステージ移動SE
     /// 2：ステージクリアSE
     /// </param>
-    internal void PlayGameSE(int SENumber)
+    public void PlayGameSE(int SENumber)
     {
         audioSource.PlayOneShot(gameSoundEffects[SENumber]);
     }

--- a/Assets/Scripts/UI/PauseUIController.cs
+++ b/Assets/Scripts/UI/PauseUIController.cs
@@ -1,20 +1,12 @@
 using System;
 using UniRx;
 using UnityEngine;
-using UnityEngine.UI;
 
+/// <summary>
+/// ポーズ表示、管理クラス
+/// </summary>
 internal class PauseUIController : MonoBehaviour
 {
-    [SerializeField, Header("ポーズパネル")]
-    private GameObject pausePanel;
-
-    [SerializeField, Header("ポーズボタン")]
-    private Button pauseButton;
-    
-    [SerializeField, Header("ポーズ解除ボタン")]
-    private Button resumeButton;
-
-
     private static Subject<string> pauseSubject = new Subject<string>();
     private static Subject<string> resumeSubject = new Subject<string>();
 
@@ -30,23 +22,11 @@ internal class PauseUIController : MonoBehaviour
         get { return resumeSubject; }
     }
 
-
-    void Start()
-    {
-        pausePanel.SetActive(false);
-
-        pauseButton.onClick.AddListener(Pause);
-
-        resumeButton.onClick.AddListener(Resume);
-    }
-
     /// <summary>
     /// ポーズボタンを押したとき
     /// </summary>
-    private void Pause()
+    internal void Pause()
     {
-        //Time.timeScale = 0.0f;
-        pausePanel.SetActive(true);
         isPaused = true;
         pauseSubject.OnNext("pause");
         Cursor.visible = true;
@@ -58,8 +38,6 @@ internal class PauseUIController : MonoBehaviour
     /// </summary>
     internal void Resume()
     {
-        //Time.timeScale = 1.0f;
-        pausePanel.SetActive(false);
         isPaused = false;
         resumeSubject.OnNext("resume");
     }

--- a/Assets/Scripts/UI/PauseUIController.cs
+++ b/Assets/Scripts/UI/PauseUIController.cs
@@ -45,7 +45,7 @@ internal class PauseUIController : MonoBehaviour
     /// </summary>
     private void Pause()
     {
-        Time.timeScale = 0.0f;
+        //Time.timeScale = 0.0f;
         pausePanel.SetActive(true);
         isPaused = true;
         pauseSubject.OnNext("pause");
@@ -58,7 +58,7 @@ internal class PauseUIController : MonoBehaviour
     /// </summary>
     internal void Resume()
     {
-        Time.timeScale = 1.0f;
+        //Time.timeScale = 1.0f;
         pausePanel.SetActive(false);
         isPaused = false;
         resumeSubject.OnNext("resume");

--- a/Assets/Scripts/UI/UIManager.cs
+++ b/Assets/Scripts/UI/UIManager.cs
@@ -30,6 +30,8 @@ internal class UIManager : MonoBehaviour
     private GameUIController gameUIController;
     [SerializeField]
     private ResultController resultController;
+    [SerializeField]
+    private PauseUIController pauseUIController;
 
     [SerializeField, Header("UIアニメーション")]
     private PanelActiveAnimation[] panelActiveAnimation;
@@ -160,5 +162,19 @@ internal class UIManager : MonoBehaviour
     internal bool getSettingActive
     {
         get { return settingPanel.activeSelf; }
+    }
+
+    public void PausePanelActive(bool active)
+    {
+        if (active)
+        {
+            panelActiveAnimation[4].Open();
+            pauseUIController.Pause();
+        }
+        else
+        {
+            panelActiveAnimation[4].Close();
+            pauseUIController.Resume();
+        }
     }
 }

--- a/Assets/Scripts/other/RigidbodyStopper.cs
+++ b/Assets/Scripts/other/RigidbodyStopper.cs
@@ -1,0 +1,34 @@
+using UnityEngine;
+using UniRx;
+using System;
+
+public class RigidbodyStopper : MonoBehaviour
+{
+    [SerializeField, Header("停止したいRigidBodyコンポーネント")]
+    private Rigidbody2D[] pauseRigidbodys;
+
+    void Start()
+    {
+        PauseUIController.OnPaused.Subscribe(_ =>
+        {
+            //pauseRigidbodys = Array.FindAll(GetComponentsInChildren<Rigidbody2D>(), (obj) => { return obj.simulated; });
+            pauseRigidbodys = UnityEngine.Object.FindObjectsOfType<Rigidbody2D>();
+            foreach (var com in pauseRigidbodys)
+            {
+                if (com != null) com.simulated = false;
+            }
+        })
+            .AddTo(this);
+        PauseUIController.OnResumed.Subscribe(_ =>
+        {
+            foreach (var com in pauseRigidbodys)
+            {
+                if (com != null) com.simulated = true;
+            }
+
+            pauseRigidbodys = null;
+        })
+            .AddTo(this);
+    }
+
+}

--- a/Assets/Scripts/other/RigidbodyStopper.cs
+++ b/Assets/Scripts/other/RigidbodyStopper.cs
@@ -1,7 +1,9 @@
 using UnityEngine;
 using UniRx;
-using System;
 
+/// <summary>
+/// Rigidbodyを停止するクラス
+/// </summary>
 public class RigidbodyStopper : MonoBehaviour
 {
     [SerializeField, Header("停止したいRigidBodyコンポーネント")]
@@ -11,19 +13,19 @@ public class RigidbodyStopper : MonoBehaviour
     {
         PauseUIController.OnPaused.Subscribe(_ =>
         {
-            //pauseRigidbodys = Array.FindAll(GetComponentsInChildren<Rigidbody2D>(), (obj) => { return obj.simulated; });
-            pauseRigidbodys = UnityEngine.Object.FindObjectsOfType<Rigidbody2D>();
-            foreach (var com in pauseRigidbodys)
+            pauseRigidbodys = FindObjectsOfType<Rigidbody2D>(); // すべてのRigidbodyを取得
+            foreach (var rb in pauseRigidbodys)
             {
-                if (com != null) com.simulated = false;
+                if (rb != null) rb.simulated = false;
             }
         })
             .AddTo(this);
+
         PauseUIController.OnResumed.Subscribe(_ =>
         {
-            foreach (var com in pauseRigidbodys)
+            foreach (var rb in pauseRigidbodys)
             {
-                if (com != null) com.simulated = true;
+                if (rb != null) rb.simulated = true;
             }
 
             pauseRigidbodys = null;

--- a/Assets/Scripts/other/RigidbodyStopper.cs.meta
+++ b/Assets/Scripts/other/RigidbodyStopper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2ae4f56fee314bf4ca083bf7825f09a0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
やったこと
・ポーズをTimeScaleではない方法で実装
　→ゲームで動いているRigidbody2Dを取得し、停止させることで実装
 - close https://github.com/tontan1122/BlockBreaker_TableTennis/issues/91

・ポーズをアニメーションしながら表示する
　→TimeScaleを使用しないため、拡大しながら表示することができた。

・ボタンクリックのSEが再生されない問題を解決
　→SEの管理をリストにしてからButtonのOnClickを見ていなかったため

