### PR TITLE
ステージ選択後すぐにスクロールバーが移動してしまう問題を解決

### DIFF
--- a/Assets/Prefabs/StagePrefabs/GameStage.prefab
+++ b/Assets/Prefabs/StagePrefabs/GameStage.prefab
@@ -213,7 +213,6 @@ GameObject:
   - component: {fileID: 5345840807493068583}
   - component: {fileID: 5345840807493068582}
   - component: {fileID: 5345840807493068569}
-  - component: {fileID: 5345840807493068568}
   m_Layer: 0
   m_Name: RightWall
   m_TagString: Wall
@@ -314,27 +313,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
---- !u!50 &5345840807493068568
-Rigidbody2D:
-  serializedVersion: 4
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5345840807493068571}
-  m_BodyType: 1
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDrag: 0
-  m_AngularDrag: 0.05
-  m_GravityScale: 1
-  m_Material: {fileID: 0}
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 0
 --- !u!1 &5345840807521223114
 GameObject:
   m_ObjectHideFlags: 0
@@ -404,7 +382,6 @@ GameObject:
   - component: {fileID: 5345840807770314376}
   - component: {fileID: 5345840807770314379}
   - component: {fileID: 5345840807770314378}
-  - component: {fileID: 5345840807770314377}
   m_Layer: 0
   m_Name: LeftWall
   m_TagString: Wall
@@ -505,27 +482,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
---- !u!50 &5345840807770314377
-Rigidbody2D:
-  serializedVersion: 4
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5345840807770314381}
-  m_BodyType: 1
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDrag: 0
-  m_AngularDrag: 0.05
-  m_GravityScale: 1
-  m_Material: {fileID: 0}
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 0
 --- !u!1 &5345840807786938931
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/StagePrefabs/NoLeftWallStage.prefab
+++ b/Assets/Prefabs/StagePrefabs/NoLeftWallStage.prefab
@@ -364,7 +364,6 @@ GameObject:
   - component: {fileID: 2870389122554275394}
   - component: {fileID: 2870389122554275395}
   - component: {fileID: 2870389122554275452}
-  - component: {fileID: 2870389122554275453}
   m_Layer: 0
   m_Name: RightWall
   m_TagString: Wall
@@ -465,27 +464,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
---- !u!50 &2870389122554275453
-Rigidbody2D:
-  serializedVersion: 4
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2870389122554275454}
-  m_BodyType: 1
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDrag: 0
-  m_AngularDrag: 0.05
-  m_GravityScale: 1
-  m_Material: {fileID: 0}
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 0
 --- !u!1 &2870389122579579055
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/StagePrefabs/NoRightWallStage.prefab
+++ b/Assets/Prefabs/StagePrefabs/NoRightWallStage.prefab
@@ -271,7 +271,6 @@ GameObject:
   - component: {fileID: 5345840807770314376}
   - component: {fileID: 5345840807770314379}
   - component: {fileID: 5345840807770314378}
-  - component: {fileID: 5345840807770314377}
   m_Layer: 0
   m_Name: LeftWall
   m_TagString: Wall
@@ -372,27 +371,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
---- !u!50 &5345840807770314377
-Rigidbody2D:
-  serializedVersion: 4
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5345840807770314381}
-  m_BodyType: 1
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDrag: 0
-  m_AngularDrag: 0.05
-  m_GravityScale: 1
-  m_Material: {fileID: 0}
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 0
 --- !u!1 &5345840807786938931
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/StagePrefabs/noCeilingStage.prefab
+++ b/Assets/Prefabs/StagePrefabs/noCeilingStage.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 152007265798936358}
   - component: {fileID: 152007265798936359}
   - component: {fileID: 152007265798936344}
-  - component: {fileID: 152007265798936345}
   m_Layer: 0
   m_Name: RightWall
   m_TagString: Wall
@@ -112,27 +111,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
---- !u!50 &152007265798936345
-Rigidbody2D:
-  serializedVersion: 4
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 152007265798936346}
-  m_BodyType: 1
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDrag: 0
-  m_AngularDrag: 0.05
-  m_GravityScale: 1
-  m_Material: {fileID: 0}
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 0
 --- !u!1 &152007265833398731
 GameObject:
   m_ObjectHideFlags: 0
@@ -444,7 +422,6 @@ GameObject:
   - component: {fileID: 152007266613061257}
   - component: {fileID: 152007266613061258}
   - component: {fileID: 152007266613061259}
-  - component: {fileID: 152007266613061256}
   m_Layer: 0
   m_Name: LeftWall
   m_TagString: Wall
@@ -545,27 +522,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
---- !u!50 &152007266613061256
-Rigidbody2D:
-  serializedVersion: 4
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 152007266613061260}
-  m_BodyType: 1
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDrag: 0
-  m_AngularDrag: 0.05
-  m_GravityScale: 1
-  m_Material: {fileID: 0}
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 0
 --- !u!1 &152007267162255867
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/TitleStage.prefab
+++ b/Assets/Prefabs/TitleStage.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 2671630360888230149}
   - component: {fileID: 2671630360888230200}
   - component: {fileID: 2671630360888230151}
-  - component: {fileID: 2671630360888230150}
   m_Layer: 0
   m_Name: LeftWall
   m_TagString: Wall
@@ -112,27 +111,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
---- !u!50 &2671630360888230150
-Rigidbody2D:
-  serializedVersion: 4
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2671630360888230148}
-  m_BodyType: 1
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDrag: 0
-  m_AngularDrag: 0.05
-  m_GravityScale: 1
-  m_Material: {fileID: 0}
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 0
 --- !u!1 &2671630361006519757
 GameObject:
   m_ObjectHideFlags: 0
@@ -441,7 +419,6 @@ GameObject:
   - component: {fileID: 2671630362173365623}
   - component: {fileID: 2671630362173365610}
   - component: {fileID: 2671630362173365609}
-  - component: {fileID: 2671630362173365608}
   m_Layer: 0
   m_Name: RightWall
   m_TagString: Wall
@@ -542,27 +519,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
---- !u!50 &2671630362173365608
-Rigidbody2D:
-  serializedVersion: 4
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2671630362173365622}
-  m_BodyType: 1
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDrag: 0
-  m_AngularDrag: 0.05
-  m_GravityScale: 1
-  m_Material: {fileID: 0}
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 0
 --- !u!1 &2671630362211545248
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/UI/UIManager.cs
+++ b/Assets/Scripts/UI/UIManager.cs
@@ -64,15 +64,12 @@ internal class UIManager : MonoBehaviour
         if (panelActive)
         {
             panelActiveAnimation[0].Open();
+            selectStageController.SetScrollPosition(movingStageNumber); // ボタンの位置調整
+            selectStageController.CheakSelectPush(level);    //ボタンのオンオフ更新
         }
         else
         {
             panelActiveAnimation[0].Close();
-        }
-        if (stageSelectPanel.activeSelf)    // パネルが表示されているなら
-        {
-            selectStageController.CheakSelectPush(level);    //ボタンのオンオフ更新
-            selectStageController.SetScrollPosition(movingStageNumber);
         }
     }
 


### PR DESCRIPTION
やったこと
・ステージ選択後すぐにスクロールバーが移動してしまう問題を解決
　→スクロールを変更するときはパネルを開いたときだけにした
- close https://github.com/tontan1122/BlockBreaker_TableTennis/issues/93
　
・不要なRigidbody2Dを削除
　→ステージの壁についていたものを削除