### PR TITLE
WebGLで画面クリックの範囲が変わってしまう問題を改善

### DIFF
--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -6863,7 +6863,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Version:1.2.2
+  m_text: Version:1.2.3
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: a55eddf9b8b477b4c926310e921e0286, type: 2}
   m_sharedMaterial: {fileID: -4180370477011686051, guid: a55eddf9b8b477b4c926310e921e0286, type: 2}

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -67,6 +67,7 @@ internal class GameManager : MonoBehaviour
 
     private void Start()
     {
+
         GlobalConst.heightUnavailableClick = Screen.height / 5 * 4; // 画面クリックができない範囲を指定
 
         // ポーズ中は弾を打てないようにする
@@ -155,6 +156,7 @@ internal class GameManager : MonoBehaviour
 
             case Scene.GAME_INIT:
                 uiManager.GameUI(true);
+                GlobalConst.heightUnavailableClick = Screen.height / 5 * 4; // 画面クリックができない範囲を指定
 
                 // パネルがActiveになったフレームだとテキスト変更ができないため1フレ待機
                 StartCoroutine(DelayFrame(Time.deltaTime, () =>


### PR DESCRIPTION
やったこと
・WebGLで画面クリックの範囲が変わってしまう問題を改善
　→画面サイズをかえれるため起きていた問題
　　ステージが始まるときに値を代入しなおすことで改善