### PR TITLE
ボールの残像の基礎部分完成、ワープホールの仮作成

### DIFF
--- a/Assets/Prefabs/Ball.prefab
+++ b/Assets/Prefabs/Ball.prefab
@@ -14,8 +14,10 @@ GameObject:
   - component: {fileID: 3242050011807985969}
   - component: {fileID: 6795908487815454937}
   - component: {fileID: 6184344713484599532}
+  - component: {fileID: 2168796759590708131}
   - component: {fileID: 3221330443540692934}
   - component: {fileID: 3221330443540692935}
+  - component: {fileID: 1427381957}
   m_Layer: 0
   m_Name: Ball
   m_TagString: Ball
@@ -78,7 +80,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 2
   m_Sprite: {fileID: 21300000, guid: 5c1d13007fb90a746bffeec18d9c4d96, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
@@ -145,8 +147,26 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4045737557895cb4b9a71440521cbed9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  boundEffectPrefab: {fileID: 8956498282791081923, guid: 94d73701b2abac64fa92736f37ba8fb8, type: 3}
-  redDeathEffectPrefab: {fileID: 6541883065928048640, guid: f87f95be76adb9548b21fb336e0d2e58, type: 3}
+  effectObjects:
+  - {fileID: 8956498282791081923, guid: 94d73701b2abac64fa92736f37ba8fb8, type: 3}
+  - {fileID: 6541883065928048640, guid: f87f95be76adb9548b21fb336e0d2e58, type: 3}
+  - {fileID: 3336651610329763008, guid: e2f334b9ebd4c0045b535ad5147103a4, type: 3}
+  effectLifeTime: 3
+--- !u!114 &2168796759590708131
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3221330443540692929}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d79dc5aadfe35924c9d948e1c708d302, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  afterImage: {fileID: 21300000, guid: 5c1d13007fb90a746bffeec18d9c4d96, type: 3}
+  timeInterval: 0.5
+  maxAfterImageNumber: 5
 --- !u!58 &3221330443540692934
 CircleCollider2D:
   m_ObjectHideFlags: 0
@@ -184,3 +204,29 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 1
   m_Constraints: 0
+--- !u!114 &1427381957
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3221330443540692929}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 044834364507f4ba0bdf7bc8ff7724ac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _targetSpriteRenderer: {fileID: 3221330443540692932}
+  _afterImageNum: 2
+  _ignoreTimeScale: 0
+  _colorList:
+  - {r: 1, g: 0, b: 0, a: 1}
+  _isSameColor: 1
+  _materialType: 1
+  _materialList:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  _span: 0.2
+  _duraction: 20
+  _fadeTime: 0.2
+  _colorNum: 1
+  _materialNum: 1

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -9531,7 +9531,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 778225145}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -4.7, y: -13.31, z: 0}
+  m_LocalPosition: {x: -6.38, y: -13.31, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -15345,7 +15345,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1292509637}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 4.65, y: -13.31, z: 0}
+  m_LocalPosition: {x: 6.94, y: -13.31, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -16901,37 +16901,9 @@ PrefabInstance:
       value: Ball
       objectReference: {fileID: 0}
     - target: {fileID: 3221330443540692933, guid: 87ad50e1e911f3e44925a99cd1dd0d27, type: 3}
-      propertyPath: moveSpeed
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 3221330443540692933, guid: 87ad50e1e911f3e44925a99cd1dd0d27, type: 3}
       propertyPath: AudioManager
       value: 
       objectReference: {fileID: 1964491437}
-    - target: {fileID: 3242050011807985969, guid: 87ad50e1e911f3e44925a99cd1dd0d27, type: 3}
-      propertyPath: bendingValue
-      value: 0.025
-      objectReference: {fileID: 0}
-    - target: {fileID: 6184344713484599532, guid: 87ad50e1e911f3e44925a99cd1dd0d27, type: 3}
-      propertyPath: outDeathEffectPrefab
-      value: 
-      objectReference: {fileID: 3336651610329763008, guid: e2f334b9ebd4c0045b535ad5147103a4, type: 3}
-    - target: {fileID: 6184344713484599532, guid: 87ad50e1e911f3e44925a99cd1dd0d27, type: 3}
-      propertyPath: effectObjects.Array.size
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 6184344713484599532, guid: 87ad50e1e911f3e44925a99cd1dd0d27, type: 3}
-      propertyPath: effectObjects.Array.data[0]
-      value: 
-      objectReference: {fileID: 8956498282791081923, guid: 94d73701b2abac64fa92736f37ba8fb8, type: 3}
-    - target: {fileID: 6184344713484599532, guid: 87ad50e1e911f3e44925a99cd1dd0d27, type: 3}
-      propertyPath: effectObjects.Array.data[1]
-      value: 
-      objectReference: {fileID: 6541883065928048640, guid: f87f95be76adb9548b21fb336e0d2e58, type: 3}
-    - target: {fileID: 6184344713484599532, guid: 87ad50e1e911f3e44925a99cd1dd0d27, type: 3}
-      propertyPath: effectObjects.Array.data[2]
-      value: 
-      objectReference: {fileID: 3336651610329763008, guid: e2f334b9ebd4c0045b535ad5147103a4, type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 87ad50e1e911f3e44925a99cd1dd0d27, type: 3}
 --- !u!1 &1446631010

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -9421,6 +9421,123 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 776321040}
   m_CullTransparentMesh: 1
+--- !u!1 &778225145
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 778225149}
+  - component: {fileID: 778225148}
+  - component: {fileID: 778225146}
+  - component: {fileID: 778225147}
+  m_Layer: 0
+  m_Name: WarpHole
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &778225146
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 778225145}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cdf8afc57f7c350498fe6638e2657ddf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  colorType: 3
+  destinationWarpHole: {fileID: 1292509639}
+  reWarpTime: 3
+--- !u!58 &778225147
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 778225145}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.5
+--- !u!212 &778225148
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 778225145}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: -1
+  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &778225149
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 778225145}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -4.7, y: -13.31, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &779715390
 GameObject:
   m_ObjectHideFlags: 0
@@ -15118,6 +15235,123 @@ RectTransform:
   m_AnchoredPosition: {x: 526, y: -1005}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1292509637
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1292509641}
+  - component: {fileID: 1292509640}
+  - component: {fileID: 1292509639}
+  - component: {fileID: 1292509638}
+  m_Layer: 0
+  m_Name: WarpHole (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!58 &1292509638
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1292509637}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.5
+--- !u!114 &1292509639
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1292509637}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cdf8afc57f7c350498fe6638e2657ddf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  colorType: 3
+  destinationWarpHole: {fileID: 778225146}
+  reWarpTime: 3
+--- !u!212 &1292509640
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1292509637}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: -1
+  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1292509641
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1292509637}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 4.65, y: -13.31, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 13
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1295809464
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Ball/BallAfterImage.cs
+++ b/Assets/Scripts/Ball/BallAfterImage.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class BallAfterImage : MonoBehaviour
+{
+    [SerializeField, Header("ボールの残像画像")]
+    private Sprite afterImage;
+
+    [SerializeField, Header("残像の間隔")]
+    private float timeInterval = 0.5f;
+
+    [SerializeField, Header("残像の枚数")]
+    private int maxAfterImageNumber = 5;
+
+    private List<GameObject> afterImages = new List<GameObject>();
+
+    private GameObject parentObject;
+
+    void Start()
+    {
+        parentObject = new GameObject("AfterImageObjects");
+    }
+
+    private void ImageColorChange(SpriteRenderer ImageRenderer)
+    {
+        //ImageRenderer.color = Color.gray;
+        ImageRenderer.color = new Color32(172, 172, 172, 100);
+    }
+
+    internal void DrawAfterImage(Transform imageTransform)
+    {
+        GameObject spriteObject = new GameObject("GeneratedSprite");
+        afterImages.Add(spriteObject);
+
+        parentObject.transform.parent = gameObject.transform;   // 子オブジェクト化
+
+        SetTransformAfterImage(imageTransform);
+        AfterImageDestroy();
+
+        SpriteRenderer spriteRenderer = spriteObject.AddComponent<SpriteRenderer>();
+        spriteRenderer.sprite = afterImage;
+        ImageColorChange(spriteRenderer);
+    }
+
+    /// <summary>
+    /// 残像のTransform設定
+    /// </summary>
+    /// <param name="imageTransform"></param>
+    private void SetTransformAfterImage(Transform imageTransform)
+    {
+        GameObject operateObject = afterImages[afterImages.Count - 1];  // リストの最後にあるものを操作するため
+        operateObject.transform.position = imageTransform.position; // 位置を設定
+        operateObject.transform.rotation = imageTransform.rotation; // 角度を設定
+        operateObject.transform.localScale = new Vector3(0.5f, 0.5f, 1); // 大きさを設定
+    }
+
+    private void AfterImageDestroy()
+    {
+        if (afterImages.Count > maxAfterImageNumber)
+        {
+            Destroy(afterImages[0].gameObject);
+            afterImages.RemoveAt(0);
+        }
+    }
+}

--- a/Assets/Scripts/Ball/BallAfterImage.cs.meta
+++ b/Assets/Scripts/Ball/BallAfterImage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d79dc5aadfe35924c9d948e1c708d302
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Ball/BallController.cs
+++ b/Assets/Scripts/Ball/BallController.cs
@@ -12,6 +12,8 @@ internal class BallController : MonoBehaviour
 
     private BallRotation ballRotation;
 
+    private BallAfterImage ballAfterImage;
+
     private Vector2 currentVelocity;
 
 
@@ -20,6 +22,7 @@ internal class BallController : MonoBehaviour
     {
         ballRigidbody = GetComponent<Rigidbody2D>();
         ballRotation = GetComponent<BallRotation>();
+        ballAfterImage = GetComponent<BallAfterImage>();
     }
 
     /// <summary>
@@ -30,6 +33,8 @@ internal class BallController : MonoBehaviour
     {
         currentVelocity = ballRigidbody.velocity;
         ballRigidbody.velocity = currentVelocity.normalized * moveSpeed;
+
+        ballAfterImage.DrawAfterImage(this.transform);
     }
 
     /// <summary>

--- a/Assets/Scripts/Gimmick/WarpHole.cs
+++ b/Assets/Scripts/Gimmick/WarpHole.cs
@@ -1,0 +1,84 @@
+using System.Collections;
+using UnityEngine;
+
+public class WarpHole : MonoBehaviour
+{
+    [Header("カラータイプ")]
+    [Header("0:None")]
+    [Header("1:Red")]
+    [Header("2:Blue")]
+    [Header("3:Yellow")]
+    [SerializeField]
+    private int colorType;
+
+    [SerializeField, Header("移動先のワープホール")]
+    private WarpHole destinationWarpHole;
+
+    [SerializeField, Header("再びワープできるようになるまでの時間")]
+    private float reWarpTime = 3.0f;
+
+    private bool isPossibleWarp = true;    // ワープできるかどうか
+
+    private void Start()
+    {
+        ChangeHoleColor();
+    }
+
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        if (collision.gameObject.CompareTag("Ball") && isPossibleWarp)
+        {
+            collision.transform.position = destinationWarpHole.transform.position;
+            ImpossibleToWarp();
+        }
+    }
+
+    /// <summary>
+    /// ワープをできなくする
+    /// </summary>
+    internal void ImpossibleToWarp()
+    {
+        isPossibleWarp = false;
+        destinationWarpHole.IsPossibleWarp = false;
+        GetComponent<SpriteRenderer>().color = new Color(179, 179, 179);
+        destinationWarpHole.GetComponent<SpriteRenderer>().color = new Color(179, 179, 179);
+        StartCoroutine(nameof(PossibleToWarp));
+    }
+
+    private IEnumerator PossibleToWarp()
+    {
+        yield return new WaitForSeconds(reWarpTime);
+        Debug.Log("ワープできるよ");
+        isPossibleWarp = true;
+        destinationWarpHole.IsPossibleWarp = true;
+        ChangeHoleColor();
+        destinationWarpHole.ChangeHoleColor();
+
+    }
+
+    internal bool IsPossibleWarp
+    {
+        get { return isPossibleWarp; }
+        set { isPossibleWarp = value; }
+    }
+
+    internal void ChangeHoleColor()
+    {
+        SpriteRenderer spriteRenderer = GetComponent<SpriteRenderer>();
+        switch (colorType)
+        {
+            case 0:
+                break;
+            case 1:
+                spriteRenderer.color = new Color(255, 0, 0);
+                break;
+            case 2:
+                spriteRenderer.color = new Color(0, 0, 255);
+                break;
+            case 3:
+                spriteRenderer.color = new Color(255, 217, 0);
+                break;
+            default: break;
+        }
+    }
+}

--- a/Assets/Scripts/Gimmick/WarpHole.cs.meta
+++ b/Assets/Scripts/Gimmick/WarpHole.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cdf8afc57f7c350498fe6638e2657ddf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
やったこと
・ボールに残像をつける
　→ボールの通った後に残像が表示できるようにした。
　　処理的な面はまだしっかり作っていなかったり、変更できる箇所もあるため、仮実装という形ではある。
 - close https://github.com/tontan1122/BlockBreaker_TableTennis/issues/116

・ワープホールを仮作成した
　→触れたらもう一つのワープホールの所にワープするというギミックを簡単に作成してみた。
　　ワープのアニメーションや見た目などはまだないため仮実装という形になる。
 - close https://github.com/tontan1122/BlockBreaker_TableTennis/issues/120