### PR TITLE
死んだときにボールの生成位置がおかしい問題を解決

### DIFF
--- a/Assets/Scripts/Ball/BallManager.cs
+++ b/Assets/Scripts/Ball/BallManager.cs
@@ -153,7 +153,6 @@ internal class BallManager : MonoBehaviour
         ballRigidbody.angularVelocity = 0;
         ballRigidbody.velocity = new Vector2(0, 0);
         circleCollider.enabled = false;  //ステージ移動中にステージと接触してしまうため
-        gameObject.transform.position = spawnPos;
         ballController.ProcessMissed();
 
         isShot = false;     //ステージ移動前にボールを発射できないようにするため

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -212,6 +212,7 @@ internal class GameManager : MonoBehaviour
                 {
                     ballManager.IsMiss = false;
                     uiManager.GameUI_MissCountText(ballManager.MissCount);   //ミスカウントの表示
+                    ballManager.SetStartPos(playerController.GetPlayerPosition);    // ボールの生成位置設定
                     stageManager.StageReset(); //ブロックを配置し直し
                 }
                 if (ballManager.MissCount == 10 && !isHintPanelActive)


### PR DESCRIPTION
やったこと
・死んだときにボールの生成位置がおかしい問題を解決
　→死んだときにも位置をリセットする関数を呼ぶようにしたら解決した。
 - close https://github.com/tontan1122/BlockBreaker_TableTennis/issues/130