### PR TITLE
ヒントパネルの消えないバグを修正

### DIFF
--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -8736,7 +8736,7 @@ MonoBehaviour:
         m_CallState: 2
       - m_Target: {fileID: 2067438181}
         m_TargetAssemblyTypeName: UIManager, Assembly-CSharp
-        m_MethodName: GameUI_HintPanel
+        m_MethodName: SwitchHintPanelVisibility
         m_Mode: 6
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -24272,7 +24272,7 @@ MonoBehaviour:
         m_CallState: 2
       - m_Target: {fileID: 2067438181}
         m_TargetAssemblyTypeName: UIManager, Assembly-CSharp
-        m_MethodName: GameUI_HintPanel
+        m_MethodName: SwitchHintPanelVisibility
         m_Mode: 6
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Assets/Scripts/UI/UIManager.cs
+++ b/Assets/Scripts/UI/UIManager.cs
@@ -125,7 +125,7 @@ internal class UIManager : MonoBehaviour
         gameUIController.ChangeStageText(level);    // ステージ数のテキスト変更
     }
 
-    internal void SwitchHintPanelVisibility(bool active)
+    public void SwitchHintPanelVisibility(bool active)
     {
         if (active)
         {

--- a/Assets/Scripts/other/RigidbodyStopper.cs
+++ b/Assets/Scripts/other/RigidbodyStopper.cs
@@ -23,9 +23,12 @@ internal class RigidbodyStopper : MonoBehaviour
 
         PauseUIController.OnResumed.Subscribe(_ =>
         {
-            foreach (var rb in pauseRigidbodys)
+            if (pauseRigidbodys != null)
             {
-                if (rb != null) rb.simulated = true;
+                foreach (var rb in pauseRigidbodys)
+                {
+                    if (rb != null) rb.simulated = true;
+                }
             }
 
             pauseRigidbodys = null;


### PR DESCRIPTION
やったこと
・ヒントパネルの消えないバグを修正
　→UIManagerの関数をpublicからinternalに変更していたため、ボタンのオンクリックから処理を行えていなかったことが原因。
　　public化して解決。
　　
・RigidbodyStopperのバグ修正
　→変数がないときでもforeachで探してしまっていたためエラーが出ていた。
　　nullの場合は処理を行わないように修正